### PR TITLE
feat: Improve code formatting and quality checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "test": "phpunit",
         "quality-checks": [
             "vendor/bin/rector process",
-            "vendor/bin/phpcbf",
+            "vendor/bin/phpcbf || true",
             "vendor/bin/phpcs || true",
             "vendor/bin/phpstan analyse --level 0 lib/ testes/"
         ]

--- a/lib/Sped/Gnre/Sefaz/LoteV2.php
+++ b/lib/Sped/Gnre/Sefaz/LoteV2.php
@@ -190,12 +190,12 @@ class LoteV2 extends Lote
             $identificacao = $gnre->createElement('identificacao');
 
             if ($gnreGuia->c34_tipoIdentificacaoDestinatario == parent::DESTINATARIO_PESSOA_JURIDICA) {
-                $destinatarioContribuinteDocumento = $gnre->createElement('CNPJ', $gnreGuia->c35_idContribuinteDestinatario);
+                $documentoIdentificacao = $gnre->createElement('CNPJ', $gnreGuia->c35_idContribuinteDestinatario);
             } else {
-                $destinatarioContribuinteDocumento = $gnre->createElement('CPF', $gnreGuia->c35_idContribuinteDestinatario);
+                $documentoIdentificacao = $gnre->createElement('CPF', $gnreGuia->c35_idContribuinteDestinatario);
             }
 
-            $identificacao->appendChild($destinatarioContribuinteDocumento);
+            $identificacao->appendChild($documentoIdentificacao);
             if ($gnreGuia->c36_inscricaoEstadualDestinatario != '') {
                 $IE = $gnre->createElement('IE', $gnreGuia->c36_inscricaoEstadualDestinatario);
                 $identificacao->appendChild($IE);
@@ -294,7 +294,8 @@ class LoteV2 extends Lote
         $doc = '10';
 
         return match ($uf) {
-            'AC', 'AL', 'AP', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA', 'MT', 'MS', 'MG', 'PA', 'PB', 'PR', 'PI', 'RN', 'RO', 'RR', 'SP', 'SE', 'TO' => '10',
+            'AC', 'AL', 'AP', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA', 'MT', 'MS', 'MG', 'PA', 'PB', 'PR', 'PI', 'RN', 'RO',
+            'RR', 'SP', 'SE', 'TO' => '10',
             'AM', 'RS' => '22',
             'PE' => $difa ? '24' : '22',
             'RJ', 'SC' => '24',
@@ -307,7 +308,8 @@ class LoteV2 extends Lote
         $doc = 'numero';
 
         return match ($uf) {
-            'AC', 'AL', 'AP', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA', 'MT', 'MS', 'MG', 'PA', 'PB', 'PR', 'PI', 'RN', 'RO', 'RR', 'SP', 'SE', 'TO' => 'numero',
+            'AC', 'AL', 'AP', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA', 'MT', 'MS', 'MG', 'PA', 'PB', 'PR', 'PI', 'RN', 'RO',
+            'RR', 'SP', 'SE', 'TO' => 'numero',
             'AM', 'PE', 'RJ', 'RS', 'SC' => 'chave',
             default => $doc,
         };

--- a/lib/Sped/Gnre/Webservice/Connection.php
+++ b/lib/Sped/Gnre/Webservice/Connection.php
@@ -49,7 +49,20 @@ class Connection
      */
     public function __construct(private readonly Setup $setup, $headers, $data)
     {
-        $this->curlOptions = [CURLOPT_PORT => 443, CURLOPT_HEADER => 1, CURLOPT_SSLVERSION => 3, CURLOPT_SSL_VERIFYHOST => 0, CURLOPT_SSL_VERIFYPEER => 0, CURLOPT_SSLCERT => $this->setup->getCertificatePemFile(), CURLOPT_SSLKEY => $this->setup->getPrivateKey(), CURLOPT_POST => 1, CURLOPT_RETURNTRANSFER => 1, CURLOPT_POSTFIELDS => $data, CURLOPT_HTTPHEADER => $headers, CURLOPT_VERBOSE => $this->setup->getDebug()];
+        $this->curlOptions = [
+            CURLOPT_PORT           => 443,
+            CURLOPT_HEADER         => 1,
+            CURLOPT_SSLVERSION     => 3,
+            CURLOPT_SSL_VERIFYHOST => 0,
+            CURLOPT_SSL_VERIFYPEER => 0,
+            CURLOPT_SSLCERT        => $this->setup->getCertificatePemFile(),
+            CURLOPT_SSLKEY         => $this->setup->getPrivateKey(),
+            CURLOPT_POST           => 1,
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_POSTFIELDS     => $data,
+            CURLOPT_HTTPHEADER     => $headers,
+            CURLOPT_VERBOSE        => $this->setup->getDebug(),
+        ];
 
         $ip = $this->setup->getProxyIp();
         $port = $this->setup->getProxyPort();

--- a/testes/Webservice/ConnectionTest.php
+++ b/testes/Webservice/ConnectionTest.php
@@ -14,7 +14,20 @@ class ConnectionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->curlOptions = [CURLOPT_PORT => 443, CURLOPT_HEADER => 1, CURLOPT_SSLVERSION => 3, CURLOPT_SSL_VERIFYHOST => 0, CURLOPT_SSL_VERIFYPEER => 0, CURLOPT_SSLCERT => null, CURLOPT_SSLKEY => null, CURLOPT_POST => 1, CURLOPT_RETURNTRANSFER => 1, CURLOPT_POSTFIELDS => '', CURLOPT_HTTPHEADER => [], CURLOPT_VERBOSE => false];
+        $this->curlOptions = [
+            CURLOPT_PORT           => 443,
+            CURLOPT_HEADER         => 1,
+            CURLOPT_SSLVERSION     => 3,
+            CURLOPT_SSL_VERIFYHOST => 0,
+            CURLOPT_SSL_VERIFYPEER => 0,
+            CURLOPT_SSLCERT        => null,
+            CURLOPT_SSLKEY         => null,
+            CURLOPT_POST           => 1,
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_POSTFIELDS     => '',
+            CURLOPT_HTTPHEADER     => [],
+            CURLOPT_VERBOSE        => false,
+        ];
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
- Format curlOptions arrays for better readability.
- Refactor LoteV2.php for variable naming consistency and match statement formatting.
- Adjust quality-checks script to allow phpcbf and phpcs to fail without stopping the entire script.